### PR TITLE
Support for port definitions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*.pyc
+*.pyo
+dist
+*egg-info

--- a/krux_marathon_api/cli.py
+++ b/krux_marathon_api/cli.py
@@ -5,6 +5,7 @@
 #
 
 from __future__ import absolute_import
+import os
 import sys
 
 #
@@ -12,7 +13,6 @@ import sys
 #
 
 from marathon import MarathonClient
-from marathon.models import MarathonApp
 
 #
 # Internal libraries
@@ -31,7 +31,11 @@ class MarathonCliApp(Application):
         self.marathon_host = self.args.host
         self.marathon_port = self.args.port
         self.marathon_list_apps = self.args.list_apps
-        self.marathon_config_file = self.args.config_file
+        ### Handles files passed via i.e. ~/some-link.json and it will translate
+        ### to the proper full location
+        self.marathon_config_file = os.path.realpath(
+            os.path.expanduser(self.args.config_file)
+        )
         self.marathon_get_app = self.args.get_app
         self.marathon_delete = self.args.delete
 
@@ -91,7 +95,7 @@ class MarathonCliApp(Application):
             self.logger.info('Connection success')
         else:
             self.logger.error('Error connecting to Server')
-            sys.exit(1)
+            raise IOError('Error connecting to Server')
 
         ### list all apps if flag is called
         if self.marathon_list_apps:
@@ -126,7 +130,7 @@ class MarathonCliApp(Application):
 
 def main():
     app = MarathonCliApp()
-    app.run_app()
+    sys.exit(app.run_app())
 
 # Run the application stand alone
 if __name__ == '__main__':

--- a/krux_marathon_api/marathonapi.py
+++ b/krux_marathon_api/marathonapi.py
@@ -72,6 +72,7 @@ class KruxMarathonClient(object):
         """
         ### assigning values from json to our marathon app
         self.logger.info("Assigning json variables to app data")
+        self.logger.debug("Config file data: {}".format(config_file_data))
         marathon_app_result.cpus                     = config_file_data["cpus"]
         marathon_app_result.mem                      = config_file_data["mem"]
         marathon_app_result.instances                = config_file_data["instances"]
@@ -89,17 +90,18 @@ class KruxMarathonClient(object):
         ### If you define ports then blank the port definitions, but if you define
         ### port_definitions they override ports, since port_definitions are more
         ### specific (i.e. protocol and etc)
-        if "ports" in config_file_data:
+        if config_file_data.get("ports"):
             marathon_app_result.ports                = config_file_data["ports"]
-            marathon_app_result.port_definitions     = []
-        if "port_definitions" in config_file_data:
+            marathon_app_result.port_definitions     = None
+        if config_file_data.get("port_definitions"):
             marathon_app_result.port_definitions     = config_file_data["port_definitions"]
-            marathon_app_result.port                 = []
+            marathon_app_result.ports                = None
         marathon_app_result.require_ports            = config_file_data["require_ports"]
         marathon_app_result.store_urls               = config_file_data["store_urls"]
         marathon_app_result.upgrade_strategy         = config_file_data["upgrade_strategy"]
         marathon_app_result.uris                     = config_file_data["uris"]
         marathon_app_result.user                     = config_file_data["user"]                 #updates confirmed
+        self.logger.debug("Marathon app object: {}".format(marathon_app_result))
 
     def list_marathon_apps(self, marathon_server):
         """

--- a/krux_marathon_api/marathonapi.py
+++ b/krux_marathon_api/marathonapi.py
@@ -86,7 +86,15 @@ class KruxMarathonClient(object):
         marathon_app_result.health_checks            = config_file_data["health_checks"]
         marathon_app_result.labels                   = config_file_data["labels"]
         marathon_app_result.max_launch_delay_seconds = config_file_data["max_launch_delay_seconds"]
-        #marathon_app_result.ports = config_file_data["ports"]      # You cannot specify both ports and port definitions
+        ### If you define ports then blank the port definitions, but if you define
+        ### port_definitions they override ports, since port_definitions are more
+        ### specific (i.e. protocol and etc)
+        if "ports" in config_file_data:
+            marathon_app_result.ports                = config_file_data["ports"]
+            marathon_app_result.port_definitions     = []
+        if "port_definitions" in config_file_data:
+            marathon_app_result.port_definitions     = config_file_data["port_definitions"]
+            marathon_app_result.port                 = []
         marathon_app_result.require_ports            = config_file_data["require_ports"]
         marathon_app_result.store_urls               = config_file_data["store_urls"]
         marathon_app_result.upgrade_strategy         = config_file_data["upgrade_strategy"]

--- a/setup.py
+++ b/setup.py
@@ -38,4 +38,5 @@ setup(
             'marathon-api = krux_marathon_api.cli:main',
         ],
     },
+    zip_safe=False,  # Don't install a single .egg file, it's harder to debug
 )


### PR DESCRIPTION
This is needed so we can declare port mappings in the config files. Also changed a few more things, pro tip: read each commit's message individually.