### PR TITLE
only update on json file changes

### DIFF
--- a/krux_marathon_api/__init__.py
+++ b/krux_marathon_api/__init__.py
@@ -1,1 +1,1 @@
-VERSION = '0.0.4'
+VERSION = '0.0.5'

--- a/krux_marathon_api/cli.py
+++ b/krux_marathon_api/cli.py
@@ -138,6 +138,7 @@ def main():
     app = MarathonCliApp()
     sys.exit(app.run_app())
 
+
 # Run the application stand alone
 if __name__ == '__main__':
     main()

--- a/krux_marathon_api/cli.py
+++ b/krux_marathon_api/cli.py
@@ -111,19 +111,22 @@ class MarathonCliApp(Application):
 
             ### get a specific marathon app
             marathon_app_result = self.api.get_marathon_app(marathon_server, config_file_data, config_file_data["id"])
+            #self.logger.info(marathon_app_result)
+
+            ### update local app data variable with config file values
+            changes_in_json = self.api.assign_config_data(config_file_data, marathon_app_result)
             self.logger.info(marathon_app_result)
 
-            ### update app data variable with config file values
-            self.api.assign_config_data(config_file_data, marathon_app_result)
-
-            ### update a marathon app
-            self.api.update_marathon_app(marathon_server, config_file_data, marathon_app_result)
+            ### update a marathon app if there was a change in the json file
+            if changes_in_json:
+                self.api.update_marathon_app(marathon_server, config_file_data, marathon_app_result)
 
         elif self.args.get_app:
             self.logger.info(self.args.get_app)
             config_file_data = None
             marathon_app_result = self.api.get_marathon_app(marathon_server, config_file_data, self.args.get_app)
             self.logger.info(marathon_app_result)
+            self.logger.info(hashlib.sha224(str(marathon_app_result)).hexdigest())
 
         ### Delete marathon app
         if self.args.delete:

--- a/krux_marathon_api/cli.py
+++ b/krux_marathon_api/cli.py
@@ -111,14 +111,15 @@ class MarathonCliApp(Application):
 
             ### get a specific marathon app
             marathon_app_result = self.api.get_marathon_app(marathon_server, config_file_data, config_file_data["id"])
-            #self.logger.info(marathon_app_result)
+            self.logger.info('marathon app before updates: ')
+            self.logger.info(marathon_app_result)
 
             ### update local app data variable with config file values
             changes_in_json = self.api.assign_config_data(config_file_data, marathon_app_result)
-            self.logger.info(marathon_app_result)
 
             ### update a marathon app if there was a change in the json file
             if changes_in_json:
+                self.logger.info('marathon app after updates: ')
                 self.api.update_marathon_app(marathon_server, config_file_data, marathon_app_result)
 
         elif self.args.get_app:

--- a/krux_marathon_api/cli.py
+++ b/krux_marathon_api/cli.py
@@ -127,7 +127,6 @@ class MarathonCliApp(Application):
             config_file_data = None
             marathon_app_result = self.api.get_marathon_app(marathon_server, config_file_data, self.args.get_app)
             self.logger.info(marathon_app_result)
-            self.logger.info(hashlib.sha224(str(marathon_app_result)).hexdigest())
 
         ### Delete marathon app
         if self.args.delete:

--- a/krux_marathon_api/marathonapi.py
+++ b/krux_marathon_api/marathonapi.py
@@ -13,6 +13,7 @@ import json
 # Third party libraries
 #
 
+import marathon
 from marathon import MarathonClient
 from marathon.models import MarathonApp
 
@@ -70,28 +71,29 @@ class KruxMarathonClient(object):
         ### iterate through our json file's values and compare them to the values
         ### on the marathon server
         for attribute, value in config_file_data.iteritems():
+            marathon_app_result_original = getattr(marathon_app_result, attribute)
             ### upgrade_strategy value returns a class an not a json, extra work
             ### needs to be done to convert this to a comparable value
-            if attribute == 'upgrade_strategy':
+            if isinstance(marathon_app_result_original, marathon.models.app.MarathonUpgradeStrategy):
                 ### the marathon api allows us to convert this attribute to json
                 marathon_app_result_original = getattr(marathon_app_result, attribute).to_json()
                 value_json = json.dumps(value)
                 if marathon_app_result_original == value_json:
-                    self.logger.info(attribute, ': ', marathon_app_result_original, ' is equal to ', value_json)
+                    self.logger.debug("%s: %s is equal to %s" % (attribute, marathon_app_result_original, value_json))
                     pass
                 else:
                     changes_in_json = True
                     setattr(marathon_app_result, attribute, value)
-                    self.logger.info('Updating ', attribute, ' from \n', marathon_app_result_original, '\nto \n', value_json)
+                    self.logger.info("Updating %s from \n %s \nto \n %s" % (attribute, marathon_app_result_original, value_json))
             else:
                 marathon_app_result_original = getattr(marathon_app_result, attribute)
                 if marathon_app_result_original == value:
-                    self.logger.info(attribute, ': ', marathon_app_result_original, ' is equal to ', value)
+                    self.logger.debug("%s: %s is equal to %s" % (attribute, marathon_app_result_original, value))
                     pass
                 else:
                     changes_in_json = True
                     setattr(marathon_app_result, attribute, value)
-                    self.logger.info('Updating ', attribute, ' from \n', marathon_app_result_original, '\nto \n', value)
+                    self.logger.info("Updating %s from \n %s \nto \n %s" % (attribute, marathon_app_result_original, value))
 
         ### ports and port_definitions don't play nicely together, if both are
         ### set, then use the more specific port_definitions and log a warning

--- a/krux_marathon_api/marathonapi.py
+++ b/krux_marathon_api/marathonapi.py
@@ -135,10 +135,6 @@ class KruxMarathonClient(object):
             except Exception as e:
                 self.logger.warn("App doesn't exist %s. Exception is %s", app_id, e)
                 sys.exit(1)
-        #self.logger.info(hashlib.sha224(str(marathon_app_result)).hexdigest())
-        #ch = json.loads(marathon_app_result.to_json())
-        #self.logger.info(ch)
-
         return marathon_app_result
 
     def update_marathon_app(self, marathon_server, config_file_data, marathon_app_result):

--- a/krux_marathon_api/marathonapi.py
+++ b/krux_marathon_api/marathonapi.py
@@ -77,21 +77,21 @@ class KruxMarathonClient(object):
                 marathon_app_result_original = getattr(marathon_app_result, attribute).to_json()
                 value_json = json.dumps(value)
                 if marathon_app_result_original == value_json:
-                    #print attribute, ': ', marathon_app_result_original, ' is equal to ', value_json
+                    self.logger.info(attribute, ': ', marathon_app_result_original, ' is equal to ', value_json)
                     pass
                 else:
                     changes_in_json = True
                     setattr(marathon_app_result, attribute, value)
-                    print 'Updating ', attribute, ' from \n', marathon_app_result_original, '\nto \n', value_json
+                    self.logger.info('Updating ', attribute, ' from \n', marathon_app_result_original, '\nto \n', value_json)
             else:
                 marathon_app_result_original = getattr(marathon_app_result, attribute)
                 if marathon_app_result_original == value:
-                    #print attribute, ': ', marathon_app_result_original, ' is equal to ', value
+                    self.logger.info(attribute, ': ', marathon_app_result_original, ' is equal to ', value)
                     pass
                 else:
                     changes_in_json = True
                     setattr(marathon_app_result, attribute, value)
-                    print 'Updating ', attribute, ' from \n', marathon_app_result_original, '\nto \n', value
+                    self.logger.info('Updating ', attribute, ' from \n', marathon_app_result_original, '\nto \n', value)
 
         ### ports and port_definitions don't play nicely together, if both are
         ### set, then use the more specific port_definitions and log a warning


### PR DESCRIPTION
Complete rewrite of assigning values from json
will only push updates to marathon if changes have been made

side note: note the print statement in the new block of code, there seems to be a bug in the logger that won't let me send this info to log so I'm using print instead. I'm guessing it has to do with sending multiple values. Feature update for later.