### PR TITLE
Ewillingham infr488 puppet fail

### DIFF
--- a/krux_marathon_api/__init__.py
+++ b/krux_marathon_api/__init__.py
@@ -1,1 +1,1 @@
-VERSION = '0.0.6'
+VERSION = '0.0.7'

--- a/krux_marathon_api/marathonapi.py
+++ b/krux_marathon_api/marathonapi.py
@@ -85,6 +85,18 @@ class KruxMarathonClient(object):
                     changes_in_json = True
                     setattr(marathon_app_result, attribute, value)
                     self.logger.info("Updating %s from \n %s \nto \n %s" % (attribute, marathon_app_result_original, value_json))
+            ### constraints and health_checks are special cases; the marathon api returns a list containing a class
+            ### let's iterate through the list and format the value of the list into
+            ### something we can actually compare to our json file
+            elif attribute == 'constraints' or attribute == 'health_checks':
+                marathon_app_result_original = getattr(marathon_app_result, attribute)
+                for i, list_val in enumerate(value):
+                    if list_val == marathon_app_result_original[i].json_repr():
+                        self.logger.debug("%s: %s is equal to %s" % (attribute, marathon_app_result_original[i].json_repr(), list_val))
+                    else:
+                        changes_in_json = True
+                        setattr(marathon_app_result, attribute, value)
+                        self.logger.info("Updating %s from \n %s \nto \n %s" % (attribute, marathon_app_result_original, value_json))
             else:
                 marathon_app_result_original = getattr(marathon_app_result, attribute)
                 if marathon_app_result_original == value:


### PR DESCRIPTION
If constraints or health_checks were set on the server, the comparison to our json value stacktraced.

 Update the code to handle the return values from the server, read the comments in the code for more details on why we are doing this.