### PR TITLE
W-9261627 dependency update for CVE-2021-20270

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -16,6 +16,3 @@ name = "pypi"
 [packages]
 krux-stdlib = "==4.0.1"
 marathon = "==0.12.0"
-
-[requires]
-python_version = "3.6"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,12 +1,10 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "8b1c55c8304994009f4394446892f6d95987c300955c859acf4b84a129110755"
+            "sha256": "31039adb0c35a72197be2096553a1f66ba0def0b99bc176e579faf90e69f346c"
         },
         "pipfile-spec": 6,
-        "requires": {
-            "python_version": "3.6"
-        },
+        "requires": {},
         "sources": [
             {
                 "name": "kruxprop",
@@ -28,30 +26,33 @@
     "default": {
         "certifi": {
             "hashes": [
-                "sha256:017c25db2a153ce562900032d5bc68e9f191e44e9a0f762f373977de9df1fbb3",
-                "sha256:25b64c7da4cd7479594d035c08c2d809eb4aab3a26e5a990ea98cc450c320f1f"
+                "sha256:1a4995114262bffbc2413b159f2a1a480c969de6e6eb13ee966d470af86af59c",
+                "sha256:719a74fb9e33b9bd44cc7f3a8d94bc35e4049deebe19ba7d8e108280cfd59830"
             ],
-            "version": "==2019.11.28"
+            "version": "==2020.12.5"
         },
         "chardet": {
             "hashes": [
-                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae",
-                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
+                "sha256:0d6f53a15db4120f2b08c94f11e7d93d2c911ee118b6b30a04ec3ee8310179fa",
+                "sha256:f864054d66fd9118f2e67044ac8981a54775ec5b67aed0441892edb553d21da5"
             ],
-            "version": "==3.0.4"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==4.0.0"
         },
         "future": {
             "hashes": [
                 "sha256:b1bead90b70cf6ec3f0710ae53a525360fa360d306a86583adc6bf83a4db537d"
             ],
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==0.18.2"
         },
         "idna": {
             "hashes": [
-                "sha256:c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407",
-                "sha256:ea8b7f6188e6fa117537c3df7da9fc686d485087abf6ac197f9c46432f7e4a3c"
+                "sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6",
+                "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"
             ],
-            "version": "==2.8"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.10"
         },
         "krux-stdlib": {
             "hashes": [
@@ -89,10 +90,11 @@
         },
         "requests": {
             "hashes": [
-                "sha256:11e007a8a2aa0323f5a921e9e6a2d7e4e67d9877e85773fba9ba6419025cbeb4",
-                "sha256:9cf5292fcd0f598c671cfc1e0d7d1a7f13bb8085e9a590f48c010551dc6c4b31"
+                "sha256:27973dd4a904a4f13b263a19c866c13b92a39ed1c964655f025f3f8d3d75b804",
+                "sha256:c210084e36a42ae6b9219e00e48287def368a26d03a048ddad7bfee44f75871e"
             ],
-            "version": "==2.22.0"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==2.25.1"
         },
         "requests-toolbelt": {
             "hashes": [
@@ -110,10 +112,11 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:a8a318824cc77d1fd4b2bec2ded92646630d7fe8619497b142c84a9e6f5a7293",
-                "sha256:f3c5fd51747d450d4dcf6f923c81f78f811aab8205fda64b0aba34a4e48b0745"
+                "sha256:2f4da4594db7e1e110a944bb1b551fdf4e6c136ad42e4234131391e21eb5b0df",
+                "sha256:e7b021f7241115872f92f43c6508082facffbd1c048e3c6e2bb9c2a157e28937"
             ],
-            "version": "==1.25.7"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
+            "version": "==1.26.4"
         }
     },
     "develop": {}

--- a/krux_marathon_api/__init__.py
+++ b/krux_marathon_api/__init__.py
@@ -1,1 +1,1 @@
-VERSION = '0.2.0'
+VERSION = '0.2.1'


### PR DESCRIPTION
## What does this PR do?

_Update dependencies_

## Why is this change being made?

_CVE-2020-28493_

GUS: [W-9261627](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07AH000000LdbmYAC/view)

## How does this PR do it?

_`pipenv lock && git commit`_

## How was this tested? How can the reviewer verify your testing?

_Manual check plus CI_
```
$ pipenv install && pipenv run python3 -m krux_marathon_api.cli -h
usage: cli.py [-h] [--log-level {critical,error,warning,info,debug}] [--log-file LOG_FILE] [--no-syslog-facility]
              [--syslog-facility SYSLOG_FACILITY] [--no-log-to-stdout] [--stats] [--stats-host STATS_HOST]
              [--stats-port STATS_PORT] [--stats-environment STATS_ENVIRONMENT] [--host HOST] [--port PORT]
              [--username USERNAME] [--password PASSWORD] [--list-apps] [--config-file CONFIG_FILE] [--get-app GET_APP]
              [--delete DELETE] [--json]

marathon_cli

optional arguments:
  -h, --help            show this help message and exit

logging:
  --log-level {critical,error,warning,info,debug}
                        Verbosity of logging. (env: LOG_LEVEL) (default: warning)
  --log-file LOG_FILE   Full-qualified path to the log file (env: LOG_FILE) (default: None)
  --no-syslog-facility  disable syslog facility
  --syslog-facility SYSLOG_FACILITY
                        syslog facility to use (env: SYSLOG_FACILITY) (default: local7)
  --no-log-to-stdout    Suppress logging to stdout/stderr (default: True)

stats:
  --stats               Enable sending statistics to statsd. (env: STATS) (default: False)
  --stats-host STATS_HOST
                        Statsd host to send statistics to. (env: STATS_HOST) (default: localhost)
  --stats-port STATS_PORT
                        Statsd port to send statistics to. (env: STATS_PORT) (default: 8125)
  --stats-environment STATS_ENVIRONMENT
                        Statsd environment. (env: STATS_ENVIRONMENT) (default: dev)

marathon_cli:
  --host HOST           Marathon server host name or IP address. (default: localhost)
  --port PORT           Marathon server port. (default: 8080)
  --username USERNAME   Marathon server username (default: None)
  --password PASSWORD   Marathon server password (default: None)
  --list-apps           Use flag to list all marathon apps. (default: False)
  --config-file CONFIG_FILE
                        Marathon config file to configure app. (default: None)
  --get-app GET_APP     app flag can be used to pass an app name to get more detailed info on a running app (default: False)
  --delete DELETE       delete the named app, if it exists (default: None)
  --json                Show output in JSON format (default: False)
```

## What gif best describes this PR or how it makes you feel?

![hackerz](https://media.giphy.com/media/115BJle6N2Av0A/giphy.gif)

## Completion checklist

- [x] The pull request has been appropriately labeled according to
  our [conventions](https://kruxdigital.jira.com/wiki/display/EN/Changes+and+Peer+Review).
- [x] The version of the package has been updated according to [Semantic Versioning](http://semver.org/).
- [x] The change has unit & integration tests as appropriate.
- [x] Documentation is up to date and correct.
- [x] Dependencies are correctly listed under `requirements.pip` and
      are up to date without going over a major version.
- [x] Stakeholders have been notified. Workflow-impacting changes have
      been appropriately socialized to avoid surprises.
- [x] The change is either small or have been canaried in the appropriate environment(s).
