### PR TITLE
W-10071953 upgrade upstream packages

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -14,5 +14,8 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-krux-stdlib = "==4.0.1"
-marathon = "==0.12.0"
+krux-stdlib = "==5.0.0"
+marathon = "==0.13.0"
+
+[requires]
+python_version = "3.6"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,10 +1,12 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "31039adb0c35a72197be2096553a1f66ba0def0b99bc176e579faf90e69f346c"
+            "sha256": "997dfa2edb5ce0b966e90508ee2a8f3b5189e8dd614ec37ff7a5b2eecb06bf3e"
         },
         "pipfile-spec": 6,
-        "requires": {},
+        "requires": {
+            "python_version": "3.6"
+        },
         "sources": [
             {
                 "name": "kruxprop",
@@ -26,40 +28,33 @@
     "default": {
         "certifi": {
             "hashes": [
-                "sha256:1a4995114262bffbc2413b159f2a1a480c969de6e6eb13ee966d470af86af59c",
-                "sha256:719a74fb9e33b9bd44cc7f3a8d94bc35e4049deebe19ba7d8e108280cfd59830"
+                "sha256:78884e7c1d4b00ce3cea67b44566851c4343c120abd683433ce934a68ea58872",
+                "sha256:d62a0163eb4c2344ac042ab2bdf75399a71a2d8c7d47eac2e2ee91b9d6339569"
             ],
-            "version": "==2020.12.5"
+            "version": "==2021.10.8"
         },
-        "chardet": {
+        "charset-normalizer": {
             "hashes": [
-                "sha256:0d6f53a15db4120f2b08c94f11e7d93d2c911ee118b6b30a04ec3ee8310179fa",
-                "sha256:f864054d66fd9118f2e67044ac8981a54775ec5b67aed0441892edb553d21da5"
+                "sha256:e019de665e2bcf9c2b64e2e5aa025fa991da8720daa3c1138cadd2fd1856aed0",
+                "sha256:f7af805c321bfa1ce6714c51f254e0d5bb5e5834039bc17db7ebe3a4cec9492b"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==4.0.0"
-        },
-        "future": {
-            "hashes": [
-                "sha256:b1bead90b70cf6ec3f0710ae53a525360fa360d306a86583adc6bf83a4db537d"
-            ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==0.18.2"
+            "markers": "python_version >= '3'",
+            "version": "==2.0.7"
         },
         "idna": {
             "hashes": [
-                "sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6",
-                "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"
+                "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff",
+                "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==2.10"
+            "markers": "python_version >= '3'",
+            "version": "==3.3"
         },
         "krux-stdlib": {
             "hashes": [
-                "sha256:de6a40138d4226c20e100e5102c8d01e46177bfa16cc4e7c3a06856c65097a4e"
+                "sha256:5e6c773157342154fb3842b4f8ae16d20fcfc1a19e3b2cfc95fcab7a7ada3a2a"
             ],
             "index": "kruxprop",
-            "version": "==4.0.1"
+            "version": "==5.0.0"
         },
         "kruxstatsd": {
             "hashes": [
@@ -76,11 +71,11 @@
         },
         "marathon": {
             "hashes": [
-                "sha256:ebc636d5736feebe165fbeb2e8f3291113e2f866bcf4edd8f33da92e1afcbb66",
-                "sha256:ec82e4a40669fca0c94ac6450424672e77ccbb2d1d42cca065198d16ac3d869f"
+                "sha256:6c6321444c3a55252109874ec70dd0db53f4c802527d14f271452213f8d24222",
+                "sha256:73fd9104cb5778b4cb1bb24601704beec6931133edc196ab2d6f81934d3dde0b"
             ],
             "index": "kruxprop",
-            "version": "==0.12.0"
+            "version": "==0.13.0"
         },
         "pystache": {
             "hashes": [
@@ -90,11 +85,11 @@
         },
         "requests": {
             "hashes": [
-                "sha256:27973dd4a904a4f13b263a19c866c13b92a39ed1c964655f025f3f8d3d75b804",
-                "sha256:c210084e36a42ae6b9219e00e48287def368a26d03a048ddad7bfee44f75871e"
+                "sha256:6c1246513ecd5ecd4528a0906f910e8f0f9c6b8ec72030dc9fd154dc1a6efd24",
+                "sha256:b8aa58f8cf793ffd8782d3d8cb19e66ef36f7aba4353eec859e74678b01b07a7"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==2.25.1"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
+            "version": "==2.26.0"
         },
         "requests-toolbelt": {
             "hashes": [
@@ -112,11 +107,11 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:2f4da4594db7e1e110a944bb1b551fdf4e6c136ad42e4234131391e21eb5b0df",
-                "sha256:e7b021f7241115872f92f43c6508082facffbd1c048e3c6e2bb9c2a157e28937"
+                "sha256:4987c65554f7a2dbf30c18fd48778ef124af6fab771a377103da0585e2336ece",
+                "sha256:c4fdf4019605b6e5423637e01bc9fe4daef873709a7973e195ceba0a62bbc844"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
-            "version": "==1.26.4"
+            "version": "==1.26.7"
         }
     },
     "develop": {}

--- a/krux_marathon_api/__init__.py
+++ b/krux_marathon_api/__init__.py
@@ -1,1 +1,1 @@
-VERSION = '0.2.1'
+VERSION = '0.2.2'


### PR DESCRIPTION
## What does this PR do?

Upgrades upstream packages.

## Why is this change being made?

[W-10071953](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00000IZytNYAT/view) _Upgrade usage of Python packages babel (CVE-2021-42771) & urllib3 (CVE-2021-33503)_

## How does this PR do it?

Self-evident.

## How was this tested? How can the reviewer verify your testing?

```bash
$ ssh -L 5080:localhost:5080 $MESOS_HOST
$ read -s MARATHON_HTTP_USERNAME
$ export MARATHON_HTTP_USERNAME
$ read -s MARATHON_HTTP_PASSWORD
$ export MARATHON_HTTP_PASSWORD
$ python -m krux_marathon_api.cli --host localhost --port 5080 --list-apps --json | jq length
2021-10-22 15:52:22,059: marathon/WARNING  : Deprecated: Using command as dict instead of string is deprecated
8
$
```

## Completion checklist

- [x] The pull request has been appropriately labeled according to
  our [conventions](https://kruxdigital.jira.com/wiki/display/EN/Changes+and+Peer+Review).
- [x] The version of the package has been updated according to [Semantic Versioning](http://semver.org/).
- [x] The change has unit & integration tests as appropriate.
- [x] Documentation is up to date and correct.
- [x] Dependencies are correctly listed under `requirements.pip` and
      are up to date without going over a major version.
- [x] Stakeholders have been notified. Workflow-impacting changes have
      been appropriately socialized to avoid surprises.
- [x] The change is either small or have been canaried in the appropriate environment(s).
